### PR TITLE
Fix bug relating to simulating findEthscriptionById

### DIFF
--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -51,7 +51,8 @@ class ContractTransaction
       transaction_index: 0,
       content_uri: uri,
       content_sha: Digest::SHA256.hexdigest(uri),
-      mimetype: mimetype
+      mimetype: mimetype,
+      mock_for_simulate_transaction: true
     }
     
     call_receipt = nil

--- a/app/models/contract_transaction_globals.rb
+++ b/app/models/contract_transaction_globals.rb
@@ -57,7 +57,11 @@ class ContractTransactionGlobals
         as_of = if Rails.env.test?
           "0xc59f53896133b7eee71167f6dbf470bad27e0af2443d06c2dfdef604a6ddf13c"
         else
-          @current_transaction.ethscription.ethscription_id
+          if @current_transaction.ethscription.mock_for_simulate_transaction
+            Ethscription.newest_first.second.ethscription_id
+          else
+            @current_transaction.ethscription.ethscription_id
+          end
         end
         
         resp = EthscriptionSync.findEthscriptionById(

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -10,6 +10,8 @@ class Ethscription < ApplicationRecord
   
   scope :newest_first, -> { order(block_number: :desc, transaction_index: :desc) }
   scope :oldest_first, -> { order(block_number: :asc, transaction_index: :asc) }
+  
+  attr_accessor :mock_for_simulate_transaction
 
   def later_ethscriptions
     Ethscription.where(


### PR DESCRIPTION
When we simulate a transaction we use a fake Ethscription as the input data. In almost all cases this is fine because the VM is a closed system that doesn't depend on external reality.

However, when performing `findEthscriptionById` we need to look up an ethscription in the base protocol indexer and we need to ensure that the state of this looked up ethscription is synced with the state of the ethscription making the VM transaction.

This means the base protocol indexer must know about the ethscription making the transaction, and this is obviously not possible if this ethscription is fake.

To fix this and enable us to simulate transactions that involve `findEthscriptionById`, in the case of a simulation we tell the base protocol indexer to return results valid as of the most recent non-fake ethscription.