### PR TITLE
Refactor inheritance to remove 'super' concept

### DIFF
--- a/app/models/contract_errors.rb
+++ b/app/models/contract_errors.rb
@@ -25,4 +25,6 @@ module ContractErrors
   class CallingNonExistentContractError < TransactionError; end
   class UnknownEthscriptionError < StandardError; end
   class FatalNetworkError < StandardError; end
+  class InvalidOverrideError < StandardError; end
+  class FunctionAlreadyDefinedError < StandardError; end
 end

--- a/app/models/contract_implementation.rb
+++ b/app/models/contract_implementation.rb
@@ -19,6 +19,10 @@ class ContractImplementation
     @contract_record = contract_record
   end
   
+  def self.mock
+    Contract.new(type: self.name).implementation
+  end
+  
   def self.abstract
     @is_abstract_contract = true
   end
@@ -117,7 +121,7 @@ class ContractImplementation
     abi.create_and_add_function(name, args, *options, returns: returns, &block)
   end
   
-  def self.constructor(args, *options, &block)
+  def self.constructor(args = {}, *options, &block)
     function(:constructor, args, *options, returns: nil, &block)
   end
   

--- a/app/models/contract_test_helper.rb
+++ b/app/models/contract_test_helper.rb
@@ -124,7 +124,7 @@ module ContractTestHelper
         "functionName": "approve",
         "args": {
           "spender": "0xF99812028817Da95f5CF95fB29a2a7EAbfBCC27E",
-          "value": "2"
+          "amount": "2"
         },
       }
     )
@@ -148,3 +148,4 @@ module ContractTestHelper
     return [url, url2]
   end
 end
+CTH = ContractTestHelper unless defined?(CTH)

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -222,5 +222,6 @@ class ContractTransaction
   
   def log_event(event)
     call_receipt.logs << event
+    event
   end
 end

--- a/spec/models/inheritance_spec.rb
+++ b/spec/models/inheritance_spec.rb
@@ -1,0 +1,219 @@
+require 'rails_helper'
+
+RSpec.describe AbiProxy, type: :model do
+  before do
+    unless defined?(Contracts::TestContract)
+      class Contracts::TestContract < ContractImplementation
+        is :ERC20
+        
+        string :public, :definedInTest
+
+        constructor(
+          name: :string,
+          symbol: :string,
+          decimals: :uint256
+        ) {
+          _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
+        }
+        
+        function :_mint, { to: :addressOrDumbContract, amount: :uint256 }, :public, :virtual, :override do
+          _ERC20._mint(to: to, amount: amount)
+          s.definedInTest = "definedInTest"
+        end
+        
+        function :nonVirtual, {}, :public do
+        end
+      end
+    end
+
+    unless defined?(Contracts::TestContractNoOverride)
+      class Contracts::TestContractNoOverride < ContractImplementation
+        is :ERC20
+        
+        constructor(
+          name: :string,
+          symbol: :string,
+          decimals: :uint256
+        ) {
+          _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
+        }
+      end
+    end
+    
+    unless defined?(Contracts::TestContractMultipleInheritance)
+      class Contracts::NonToken < ContractImplementation
+        string :public, :definedInNonToken
+        
+        constructor() {}
+        
+        event :Greet, { greeting: :string }
+        
+        function :_mint, { to: :addressOrDumbContract, amount: :uint256 }, :public, :virtual do
+          emit :Greet, greeting: "Hello"
+          s.definedInNonToken = "definedInNonToken"
+        end
+      end
+    end
+    
+    unless defined?(Contracts::TestContractMultipleInheritance)
+      class Contracts::TestContractMultipleInheritance < ContractImplementation
+        is :TestContract, :NonToken
+        
+        string :public, :definedHere
+  
+        constructor(
+          name: :string,
+          symbol: :string,
+          decimals: :uint256
+        ) {
+          _TestContract.constructor(name: name, symbol: symbol, decimals: decimals)
+          _NonToken.constructor()
+          
+          s.definedHere = "definedHere"
+        }
+  
+        function :_mint, { to: :addressOrDumbContract, amount: :uint256 }, :public, :override do
+          _TestContract._mint(to: to, amount: amount)
+          _NonToken._mint(to: to, amount: amount)
+          _ERC20._mint(to: to, amount: amount)
+        end
+      end
+    end
+  end
+  
+  it "allows a child contract to override a parent contract's function" do
+    deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "TestContract",
+        "constructorArgs": {
+          "name": "Test Token",
+          "symbol": "TT",
+          "decimals": 18
+        },
+      }
+    )
+
+    call_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'call',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "contractId": deploy_receipt.contract_id,
+        "functionName": "_mint",
+        "args": {
+          "to": "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+          "amount": "5"
+        },
+      }
+    )
+  end
+
+  it "does not allow a child contract to call a parent contract's function without overriding it" do
+    deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "TestContractNoOverride",
+        "constructorArgs": {
+          "name": "Test Token",
+          "symbol": "TT",
+          "decimals": 18
+        },
+      }
+    )
+
+    trigger_contract_interaction_and_expect_call_error(
+      command: 'call',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "contractId": deploy_receipt.contract_id,
+        "functionName": "_mint",
+        "args": {
+          "to": "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+          "amount": "5"
+        },
+      }
+    )
+  end
+  
+  it "allows a child contract to override a parent contract's function and call the parent contract's function using the _PARENT prefix" do
+    deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "TestContractMultipleInheritance",
+        "constructorArgs": {
+          "name": "Test Token",
+          "symbol": "TT",
+          "decimals": 18
+        },
+      }
+    )
+  
+    call_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'call',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "contractId": deploy_receipt.contract_id,
+        "functionName": "_mint",
+        "args": {
+          "to": "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+          "amount": "5"
+        },
+      }
+    )
+    
+    expect(call_receipt.logs.map{|i| i['event']}.sort)
+    .to eq(['Greet', 'Transfer', 'Transfer'].sort)
+    
+    expect(call_receipt.contract.current_state.state['totalSupply']).to eq(10)
+    
+    expect(call_receipt.contract.current_state.state.
+      slice('definedHere', 'definedInTest', 'definedInNonToken').values.sort).to eq(
+        ['definedHere', 'definedInTest', 'definedInNonToken'].sort
+      )
+  end
+  
+  it "raises an error when declaring override without overriding anything" do
+    expect {
+      class Contracts::TestContractOverrideNonVirtual < ContractImplementation
+        function :_mint, {}, :public, :override do
+        end
+      end
+    }.to raise_error(ContractErrors::InvalidOverrideError)
+  end
+  
+  it "raises an error when trying to override a non-virtual function" do
+    expect {
+      class Contracts::TestContractOverrideNonVirtual < ContractImplementation
+        is :TestContract
+  
+        function :nonVirtual, {}, :public, :override do
+          _ERC20._mint(to: to, amount: amount)
+        end
+      end
+    }.to raise_error(ContractErrors::InvalidOverrideError)
+  end
+  
+  it "raises an error when trying to override a virtual function without the override modifier" do
+    expect {
+      class Contracts::TestContractOverrideWithoutModifier < ContractImplementation
+        is :TestContract
+  
+        function :_mint, { to: :addressOrDumbContract, amount: :uint256 }, :public do
+          _TestContract._mint(to: to, amount: amount)
+        end
+      end
+    }.to raise_error(ContractErrors::InvalidOverrideError)
+  end
+  
+  it "raises an error when defining the same function twice in a contract" do
+    expect {
+      class Contracts::TestContractDuplicateFunction < ContractImplementation
+        function(:_mint, { to: :addressOrDumbContract, amount: :uint256 }, :public) {}
+        function(:_mint, { to: :addressOrDumbContract, amount: :uint256 }, :public) {}
+      end
+    }.to raise_error(ContractErrors::FunctionAlreadyDefinedError)
+  end
+end


### PR DESCRIPTION
Rubidity can't use Ruby's built in `super` functionality because of the way we define functions and also because Ruby doesn't support multiple inheritance. So Rubidity must implement inheritance from scratch.

The initial implementation attempted to create a "poor man's" `super` from scratch using `_super_{method_name}` but all it did was grab the closest parent's implementation and run it in the context of the child.

This breaks with an infinite loop in the case the parent also calls `_super_{method_name}` because the parent's function is evaluated in the context of the child and so the parent's call to `_super_{method_name}` is the same the child calling it again, causing a loop.

To fix this, we remove the notion of `super`. Instead, you must specify the parent you are calling with something like `_ERC20.transfer()`. (Unfortunately we can't have the good version `ERC20.transfer()` in Ruby without some annoying tricks I don't think are worth it right now).

For backwards compatibility and because it looks nice, `ERC20()` is left in as an alias of `_ERC20.constructor()`