### PR TITLE
Add more ints, refactor type system

### DIFF
--- a/app/models/abi_proxy.rb
+++ b/app/models/abi_proxy.rb
@@ -109,7 +109,6 @@ class AbiProxy
     if data.respond_to?(name)
       data.send(name, *args, &block)
     else
-      binding.pry
       super
     end
   end
@@ -201,12 +200,12 @@ class AbiProxy
       as_typed = if other_args.is_a?(Array)
         args.keys.zip(other_args).map do |key, value|
           type = args[key]
-          [key, TypedVariable.create(type, value)]
+          [key, TypedVariable.create_or_validate(type, value)]
         end.to_h
       else
         other_args.each.with_object({}) do |(key, value), acc|
           type = args[key]
-          acc[key.to_sym] = TypedVariable.create(type, value)
+          acc[key.to_sym] = TypedVariable.create_or_validate(type, value)
         end
       end
       
@@ -216,7 +215,7 @@ class AbiProxy
     
     def convert_return_to_typed_variable(ret_val)
       return ret_val if ret_val.nil? || returns.nil?
-      TypedVariable.create(returns, ret_val)
+      TypedVariable.create_or_validate(returns, ret_val)
     end
     
     def self.create(name, args, *options, returns: nil, &block)

--- a/app/models/array_type.rb
+++ b/app/models/array_type.rb
@@ -20,20 +20,20 @@ class ArrayType < TypedVariable
     end
   
     def [](index)
-      index_var = TypedVariable.create(:uint256, index)
+      index_var = TypedVariable.create_or_validate(:uint256, index)
       
       raise "Index out of bounds" if index_var >= data.size
 
       value = data[index_var]
-      value || TypedVariable.create(value_type)
+      value || TypedVariable.create_or_validate(value_type)
     end
   
     def []=(index, value)
-      index_var = TypedVariable.create(:uint256, index)
+      index_var = TypedVariable.create_or_validate(:uint256, index)
       
       raise "Sparse arrays are not supported" if index_var > data.size
 
-      val_var = TypedVariable.create(value_type, value)
+      val_var = TypedVariable.create_or_validate(value_type, value)
       
       self.data[index_var] ||= val_var
       self.data[index_var].value = val_var.value

--- a/app/models/contract_errors.rb
+++ b/app/models/contract_errors.rb
@@ -10,7 +10,10 @@ module ContractErrors
     
     def message
       return super if contract.blank?
-      "#{contract.class.name.demodulize} error: " + super + " (contract id: #{contract.contract_id})"
+      
+      trace = !Rails.env.production? ? backtrace.join("\n") : ''
+      
+      "#{contract.class.name.demodulize} error: " + super + "#{trace} (contract id: #{contract.contract_id})"
     end
   end
   

--- a/app/models/contract_implementation.rb
+++ b/app/models/contract_implementation.rb
@@ -188,11 +188,11 @@ class ContractImplementation
   end
   
   def address(i)
-    return TypedVariable.create(:address) if i == 0
-
-    if i.is_a?(TypedVariable) && i.type == Type.create(:addressOrDumbContract)
+    if i.is_a?(TypedVariable) && i.type.addressOrDumbContract?
       return TypedVariable.create(:address, i.value)
     end
+    
+    return TypedVariable.create(:address) if i == 0
     
     raise "Not implemented"
   end

--- a/app/models/contract_test_helper.rb
+++ b/app/models/contract_test_helper.rb
@@ -148,4 +148,4 @@ module ContractTestHelper
     return [url, url2]
   end
 end
-CTH = ContractTestHelper unless defined?(CTH)
+$cth = ContractTestHelper

--- a/app/models/contract_transaction_globals.rb
+++ b/app/models/contract_transaction_globals.rb
@@ -51,7 +51,7 @@ class ContractTransactionGlobals
     end
     
     def findEthscriptionById(ethscription_id)
-      ethscription_id = TypedVariable.create(:ethscriptionId, ethscription_id).value
+      ethscription_id = TypedVariable.create_or_validate(:ethscriptionId, ethscription_id).value
       
       begin
         as_of = if Rails.env.test?

--- a/app/models/contracts/erc20.rb
+++ b/app/models/contracts/erc20.rb
@@ -8,14 +8,14 @@ class Contracts::ERC20 < ContractImplementation
 
   string :public, :name
   string :public, :symbol
-  uint256 :public, :decimals
+  uint8 :public, :decimals
   
   uint256 :public, :totalSupply
 
   mapping ({ addressOrDumbContract: :uint256 }), :public, :balanceOf
   mapping ({ addressOrDumbContract: mapping(addressOrDumbContract: :uint256) }), :public, :allowance
   
-  constructor(name: :string, symbol: :string, decimals: :uint256) {
+  constructor(name: :string, symbol: :string, decimals: :uint8) {
     s.name = name
     s.symbol = symbol
     s.decimals = decimals

--- a/app/models/contracts/public_mint_erc20.rb
+++ b/app/models/contracts/public_mint_erc20.rb
@@ -9,7 +9,7 @@ class Contracts::PublicMintERC20 < ContractImplementation
     symbol: :string,
     maxSupply: :uint256,
     perMintLimit: :uint256,
-    decimals: :uint256
+    decimals: :uint8
   ) {
     ERC20(name: name, symbol: symbol, decimals: decimals)
     s.maxSupply = maxSupply

--- a/app/models/mapping_type.rb
+++ b/app/models/mapping_type.rb
@@ -20,20 +20,20 @@ class MappingType < TypedVariable
     end
     
     def [](key_var)
-      key_var = TypedVariable.create(key_type, key_var)
+      key_var = TypedVariable.create_or_validate(key_type, key_var)
       value = data[key_var]
 
       if value_type.mapping? && value.nil?
-        value = TypedVariable.create(value_type)
+        value = TypedVariable.create_or_validate(value_type)
         data[key_var] = value
       end
 
-      value || TypedVariable.create(value_type)
+      value || TypedVariable.create_or_validate(value_type)
     end
 
     def []=(key_var, value)
-      key_var = TypedVariable.create(key_type, key_var)
-      val_var = TypedVariable.create(value_type, value)
+      key_var = TypedVariable.create_or_validate(key_type, key_var)
+      val_var = TypedVariable.create_or_validate(value_type, value)
 
       if value_type.mapping?
         val_var = Proxy.new(key_type: value_type.key_type, value_type: value_type.value_type)

--- a/app/models/state_proxy.rb
+++ b/app/models/state_proxy.rb
@@ -20,16 +20,11 @@ class StateProxy
     var = state_variables[var_name]
     
     return super if var.nil?
-    
-    return var.typed_variable unless is_setter
-      
-    begin
-      var.typed_variable.value = args.first
-    rescue StateVariableMutabilityError => e
-      message = "immutability error for #{var_name}: #{e.message}"
-      raise ContractRuntimeError.new(message, contract)
-    rescue StateVariableTypeError => e
-      raise ContractRuntimeError.new(e.message, contract)
+
+    if is_setter
+      var.typed_variable = args.first
+    else
+      var.typed_variable
     end
   end
   

--- a/app/models/state_variable.rb
+++ b/app/models/state_variable.rb
@@ -115,12 +115,7 @@ class StateVariable
   end
   
   def ==(other)
-    other.is_a?(self.class) &&
-      typed_variable == other.typed_variable &&
-      name == other.name &&
-      visibility == other.visibility &&
-      immutable == other.immutable &&
-      constant == other.constant
+    other.is_a?(self.class) && typed_variable == other.typed_variable
   end
   
   def !=(other)

--- a/app/models/state_variable.rb
+++ b/app/models/state_variable.rb
@@ -97,6 +97,23 @@ class StateVariable
     typed_variable.respond_to?(name, include_private) || super
   end
   
+  def typed_variable=(new_value)
+    if new_value.is_a?(TypedVariable)
+      unless type.can_be_assigned_from?(new_value.type)
+        raise VariableTypeError.new("invalid #{type}: #{new_value.inspect}")
+      end
+  
+      typed_variable.value = new_value.value
+    else
+      typed_variable.value = new_value
+    end
+  rescue StateVariableMutabilityError => e
+    message = "immutability error for #{var.name}: #{e.message}"
+    raise ContractRuntimeError.new(message, contract)
+  rescue StateVariableTypeError => e
+    raise ContractRuntimeError.new(e.message, contract)
+  end
+  
   def ==(other)
     other.is_a?(self.class) &&
       typed_variable == other.typed_variable &&

--- a/app/models/state_variable.rb
+++ b/app/models/state_variable.rb
@@ -99,11 +99,7 @@ class StateVariable
   
   def typed_variable=(new_value)
     if new_value.is_a?(TypedVariable)
-      unless type.can_be_assigned_from?(new_value.type)
-        raise VariableTypeError.new("invalid #{type}: #{new_value.inspect}")
-      end
-  
-      typed_variable.value = new_value.value
+      @typed_variable = TypedVariable.create_or_validate(type, new_value)
     else
       typed_variable.value = new_value
     end

--- a/spec/models/inheritance_spec.rb
+++ b/spec/models/inheritance_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AbiProxy, type: :model do
         constructor(
           name: :string,
           symbol: :string,
-          decimals: :uint256
+          decimals: :uint8
         ) {
           _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
         }
@@ -33,7 +33,7 @@ RSpec.describe AbiProxy, type: :model do
         constructor(
           name: :string,
           symbol: :string,
-          decimals: :uint256
+          decimals: :uint8
         ) {
           _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
         }
@@ -64,7 +64,7 @@ RSpec.describe AbiProxy, type: :model do
         constructor(
           name: :string,
           symbol: :string,
-          decimals: :uint256
+          decimals: :uint8
         ) {
           _TestContract.constructor(name: name, symbol: symbol, decimals: decimals)
           _NonToken.constructor()

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -1,0 +1,79 @@
+# spec/models/type_spec.rb
+require 'rails_helper'
+
+RSpec.describe Type, type: :model do
+  describe '#can_be_assigned_from?' do
+    it 'returns true if types are the same' do
+      type = Type.create(:uint256)
+      expect(type.can_be_assigned_from?(Type.create(:uint256))).to be true
+    end
+
+    it 'returns true if both types are integer types and the number of bits of the first type is greater than or equal to the number of bits of the second type' do
+      type = Type.create(:uint256)
+      expect(type.can_be_assigned_from?(Type.create(:uint128))).to be true
+    end
+
+    it 'returns true if the first type is addressOrDumbContract and the second type is address or dumbContract' do
+      type = Type.create(:addressOrDumbContract)
+      expect(type.can_be_assigned_from?(Type.create(:address))).to be true
+      expect(type.can_be_assigned_from?(Type.create(:dumbContract))).to be true
+    end
+
+    it 'returns false otherwise' do
+      type = Type.create(:uint128)
+      expect(type.can_be_assigned_from?(Type.create(:uint256))).to be false
+    end
+    
+    it 'returns true if a literal can be assigned to the type' do
+      type = Type.create(:uint256)
+      literal = 123
+      typed_variable = TypedVariable.create_or_validate(type, literal)
+      expect(type.can_be_assigned_from?(typed_variable.type)).to be true
+    end
+  
+    it 'raises a VariableTypeError if a literal cannot be assigned to the type' do
+      type = Type.create(:uint256)
+      literal = "abcd" # This is a string, not an integer
+      expect { TypedVariable.create_or_validate(type, literal) }.to raise_error(
+        ContractErrors::VariableTypeError
+      )
+    end
+  end
+  
+  describe '#values_can_be_compared?' do
+    it 'returns true if types are compatible' do
+      type = Type.create(:uint256)
+      expect(type.values_can_be_compared?(Type.create(:uint256))).to be true
+    end
+  
+    it 'returns true if both types are integer types' do
+      type = Type.create(:uint256)
+      expect(type.values_can_be_compared?(Type.create(:uint128))).to be true
+    end
+  
+    it 'returns true if either type is address or dumbContract and the other type is addressOrDumbContract' do
+      type = Type.create(:address)
+      expect(type.values_can_be_compared?(Type.create(:addressOrDumbContract))).to be true
+    end
+  
+    it 'returns false otherwise' do
+      type = Type.create(:uint128)
+      expect(type.values_can_be_compared?(Type.create(:address))).to be false
+    end
+    
+    it 'returns true if a literal can be compared with the type' do
+      type = Type.create(:uint256)
+      literal = 123
+      typed_variable = TypedVariable.create_or_validate(type, literal)
+      expect(type.values_can_be_compared?(typed_variable.type)).to be true
+    end
+  
+    it 'returns false if a literal cannot be compared with the type' do
+      type = Type.create(:uint256)
+      literal = "abcd" # This is a string, not an integer
+      expect { TypedVariable.create_or_validate(type, literal) }.to raise_error(
+        ContractErrors::VariableTypeError
+      )
+    end
+  end
+end

--- a/spec/models/typed_variable_spec.rb
+++ b/spec/models/typed_variable_spec.rb
@@ -1,0 +1,25 @@
+# spec/models/typed_variable_spec.rb
+require 'rails_helper'
+
+RSpec.describe TypedVariable, type: :model do
+  describe '.create_or_validate' do
+    it 'returns the same TypedVariable if the value is a TypedVariable and its type can be assigned from the specified type' do
+      typed_variable = TypedVariable.create(:uint256, 1)
+      expect(TypedVariable.create_or_validate(:uint256, typed_variable)).to eq typed_variable
+    end
+
+    it 'is fine to go up in bits' do
+      typed_variable = TypedVariable.create(:uint128, 1)
+      expect(TypedVariable.create_or_validate(:uint256, typed_variable)).to be_a(TypedVariable)
+    end
+
+    it 'creates a new TypedVariable if the value is not a TypedVariable' do
+      expect(TypedVariable.create_or_validate(:uint256, 1)).to be_a TypedVariable
+    end
+    
+    it 'raises a VariableTypeError if the value is a TypedVariable and its type cannot be assigned from the specified type' do
+      typed_variable = TypedVariable.create(:uint256, 2**128) # This value is too large for uint128
+      expect { TypedVariable.create_or_validate(:uint128, typed_variable) }.to raise_error(ContractErrors::VariableTypeError)
+    end
+  end
+end


### PR DESCRIPTION
My original goal was to add the missing `int`s and `uint`s below the `uint256` / `int256` types we already have.

There is some subtlety to these types, however. All `uint` / `int` values can be compared, but values from larger types cannot be assigned to variables of smaller types.

I.e., you can compare `uint256` and `uint8`, you can assign `uint8` to `uint256`, but you can't assign `uint256` to `uint8`.

To capture this logic I formalized the `can_be_assigned_from?` and `values_can_be_compared?` relationships in the `Type` model.

I refactored `TypedVariable.create` into `create` and `create_or_validate` so we are forced to know whether we're dealing with a literal or an existing `TypedVariable`

Finally I updated the `==` on `TypedVariable` to raise an exception when the types aren't comparable versus returning false, as is in the case in Solidity.

I also relaxed an incorrectly-restrictive `==` on `StateVariable`