### PR TITLE
Use more annoying syntax for calling parent constructors

### DIFF
--- a/app/models/abi_proxy.rb
+++ b/app/models/abi_proxy.rb
@@ -36,10 +36,6 @@ class AbiProxy
       end
   
       contract_class.class_eval do
-        define_method(parent.name.demodulize) do |*args, **kwargs|
-          send("__#{parent.name.demodulize}__constructor", *args, **kwargs)
-        end
-        
         define_method("_" + parent.name.demodulize) do
           contract_instance = self
           Object.new.tap do |proxy|

--- a/app/models/contracts/ether_erc20_bridge.rb
+++ b/app/models/contracts/ether_erc20_bridge.rb
@@ -14,7 +14,7 @@ class Contracts::EtherERC20Bridge < ContractImplementation
     symbol: :string,
     trustedSmartContract: :address
   ) {
-    ERC20(name: name, symbol: symbol, decimals: 18)
+    _ERC20.constructor(name: name, symbol: symbol, decimals: 18)
     
     s.trustedSmartContract = trustedSmartContract
   }

--- a/app/models/contracts/ethscription_erc20_bridge.rb
+++ b/app/models/contracts/ethscription_erc20_bridge.rb
@@ -21,7 +21,7 @@ class Contracts::EthscriptionERC20Bridge < ContractImplementation
     trustedSmartContract: :address,
     ethscriptionDeployId: :ethscriptionId
   ) {
-    ERC20(name: name, symbol: symbol, decimals: 18)
+    _ERC20.constructor(name: name, symbol: symbol, decimals: 18)
     
     s.trustedSmartContract = trustedSmartContract
     s.ethscriptionDeployId = ethscriptionDeployId

--- a/app/models/contracts/generative_erc721.rb
+++ b/app/models/contracts/generative_erc721.rb
@@ -17,7 +17,7 @@ class Contracts::GenerativeERC721 < ContractImplementation
     description: :string,
     maxPerAddress: :uint256
   ) {
-    ERC721(name: name, symbol: symbol)
+    _ERC721.constructor(name: name, symbol: symbol)
     
     s.maxSupply = maxSupply
     s.maxPerAddress = maxPerAddress

--- a/app/models/contracts/open_edition_erc721.rb
+++ b/app/models/contracts/open_edition_erc721.rb
@@ -18,7 +18,7 @@ class Contracts::OpenEditionERC721 < ContractImplementation
     mintStart: :datetime,
     mintEnd: :datetime
   ) {
-    ERC721(name: name, symbol: symbol)
+    _ERC721.constructor(name: name, symbol: symbol)
     
     s.maxPerAddress = maxPerAddress
     s.description = description

--- a/app/models/contracts/public_mint_erc20.rb
+++ b/app/models/contracts/public_mint_erc20.rb
@@ -11,7 +11,7 @@ class Contracts::PublicMintERC20 < ContractImplementation
     perMintLimit: :uint256,
     decimals: :uint8
   ) {
-    ERC20(name: name, symbol: symbol, decimals: decimals)
+    _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
     s.maxSupply = maxSupply
     s.perMintLimit = perMintLimit
   }


### PR DESCRIPTION
`ERC(args)` is better used for deploying contracts than as syntactic sugar for calling parent constructors. Someday we'll get rid of the leading _.