### PR TITLE
Eliminate the `Contracts::` prefix on contract types

### DIFF
--- a/app/models/contract_implementation.rb
+++ b/app/models/contract_implementation.rb
@@ -13,7 +13,7 @@ class ContractImplementation
   def initialize(contract_record)
     @state_proxy = StateProxy.new(
       contract_record,
-      contract_record.type.constantize.state_variable_definitions
+      contract_record.implementation_class.state_variable_definitions
     )
     
     @contract_record = contract_record
@@ -113,10 +113,9 @@ class ContractImplementation
   end
   
   def self.is(*constants)
-    self.parent_contracts += constants.map{|i| "Contracts::#{i}".safe_constantize}
+    self.parent_contracts += constants.map{|i| "Contracts::#{i}".constantize}
     self.parent_contracts = self.parent_contracts.uniq
   end
-  
   
   def self.linearize_contracts(contract, processed = [])
     return [] if processed.include?(contract)

--- a/spec/models/inheritance_spec.rb
+++ b/spec/models/inheritance_spec.rb
@@ -81,6 +81,21 @@ RSpec.describe AbiProxy, type: :model do
     end
   end
   
+  it "won't deploy abstract contract" do
+    deploy_receipt = trigger_contract_interaction_and_expect_deploy_error(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "ERC20",
+        "constructorArgs": {
+          "name": "Test Token",
+          "symbol": "TT",
+          "decimals": 18
+        },
+      }
+    )
+  end
+  
   it "allows a child contract to override a parent contract's function" do
     deploy_receipt = trigger_contract_interaction_and_expect_success(
       command: 'deploy',


### PR DESCRIPTION
The initial contract implementation used Rails's Single Table Inheritance pattern which requires you to put the full class name in the `type` column.

We ditched STI a while ago and yet are still storing types like `Contracts::PublicMintERC20`. Now that we're invalidating all the old data anyway it's a good time to eliminate the annoying prefix!