### PR TITLE
Better contract type casting

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -11,7 +11,7 @@ class Contract < ApplicationRecord
   attr_accessor :current_transaction
   attr_reader :implementation
   
-  delegate :msg, to: :implementation
+  delegate :msg, :implements?, to: :implementation
   
   def self.create_from_user!(deployer:, creation_ethscription_id:, type:)
     unless valid_contract_types.include?(type)

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -8,7 +8,7 @@ class ContractTransaction
   :current_contract
   
   def self.required_mimetype
-    "application/vnd.esc".freeze
+    "application/vnd.esc"
   end
   
   def tx

--- a/app/models/contracts/erc20_liquidity_pool.rb
+++ b/app/models/contracts/erc20_liquidity_pool.rb
@@ -8,13 +8,13 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
   end
   
   function :addLiquidity, {token0Amount: :uint256, token1Amount: :uint256}, :public do
-    DumbContract(s.token0).transferFrom(
+    ERC20(s.token0).transferFrom(
       from: msg.sender,
       to: address(this),
       amount: token0Amount
     )
     
-    DumbContract(s.token1).transferFrom(
+    ERC20(s.token1).transferFrom(
       from: msg.sender,
       to: address(this),
       amount: token1Amount
@@ -23,8 +23,8 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
   
   function :reserves, {}, :public, :view, returns: :string do
     jsonData = {
-      token0: DumbContract(s.token0).balanceOf(address(this)),
-      token1: DumbContract(s.token1).balanceOf(address(this))
+      token0: ERC20(s.token0).balanceOf(address(this)),
+      token1: ERC20(s.token1).balanceOf(address(this))
     }.to_json
     
     return "data:application/json,#{jsonData}"
@@ -35,8 +35,8 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
     outputToken: :address,
     inputAmount: :uint256
   }, :public, :view, returns: :uint256 do
-    inputReserve = DumbContract(inputToken).balanceOf(address(this))
-    outputReserve = DumbContract(outputToken).balanceOf(address(this))
+    inputReserve = ERC20(inputToken).balanceOf(address(this))
+    outputReserve = ERC20(outputToken).balanceOf(address(this))
     
     ((inputAmount * outputReserve) / (inputReserve + inputAmount)).to_i
   end
@@ -57,17 +57,17 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
       inputAmount: inputAmount
     )
     
-    outputReserve = DumbContract(outputToken).balanceOf(address(this))
+    outputReserve = ERC20(outputToken).balanceOf(address(this))
     
     require(outputAmount <= outputReserve, "Insufficient output reserve")
   
-    DumbContract(inputToken).transferFrom(
+    ERC20(inputToken).transferFrom(
       from: msg.sender,
       to: address(this),
       amount: inputAmount
     )
   
-    DumbContract(outputToken).transfer(
+    ERC20(outputToken).transfer(
       msg.sender,
       outputAmount
     )

--- a/spec/models/contract_implementation_spec.rb
+++ b/spec/models/contract_implementation_spec.rb
@@ -1,0 +1,156 @@
+require 'rails_helper'
+
+class Contracts::ERC20Receiver < ContractImplementation
+  is :ERC20
+  
+  constructor() {
+    _ERC20.constructor(name: "bye", symbol: "B", decimals: 18)
+  }
+end
+
+class Contracts::Receiver < ContractImplementation
+  event :MsgSender, { sender: :address }
+  
+  constructor() {}
+  
+  function :receiveCall, { }, :public, returns: :uint256 do
+    emit :MsgSender, sender: msg.sender
+    
+    return block.number
+  end
+  
+  function :internalCall, { }, :internal do
+  end
+  
+  function :name, {}, :public, :view, returns: :string do
+    return "hi"
+  end
+end
+
+class Contracts::Caller < ContractImplementation
+  event :BlockNumber, { number: :uint256 }
+  
+  constructor() {}
+  
+  function :makeCall, { receiver: :address }, :public do
+    resp = Receiver(receiver).receiveCall()
+    
+    emit :BlockNumber, number: block.number
+    emit :BlockNumber, number: resp
+  end
+  
+  function :callInternal, { receiver: :address }, :public do
+    Receiver(receiver).internalCall()
+  end
+  
+  function :testImplements, { receiver: :address }, :public do
+    ERC20(receiver).name()
+  end
+end
+
+RSpec.describe ContractImplementation, type: :model do
+  it "sets msg.sender correctly when one contract calls another" do
+    caller_deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "Caller",
+        "constructorArgs": {},
+      }
+    )
+
+    receiver_deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "Receiver",
+        "constructorArgs": {},
+      }
+    )
+
+    call_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'call',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "contract": caller_deploy_receipt.address,
+        "functionName": "makeCall",
+        "args": {
+          "receiver": receiver_deploy_receipt.address,
+        },
+      }
+    )
+    
+    block_number_logs = call_receipt.logs.select { |log| log['event'] == 'BlockNumber' }
+    expect(block_number_logs.size).to eq(2)
+    expect(block_number_logs[0]['data']['number']).to eq(block_number_logs[1]['data']['number'])
+
+    expect(call_receipt.logs).to include(
+      hash_including('event' => 'MsgSender', 'data' => { 'sender' => caller_deploy_receipt.address })
+    )
+    
+    trigger_contract_interaction_and_expect_call_error(
+      command: 'call',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "contract": caller_deploy_receipt.address,
+        "functionName": "callInternal",
+        "args": {
+          "receiver": receiver_deploy_receipt.address,
+        },
+      }
+    )
+  end
+  
+  it "raises an error when trying to cast a non-ERC20 contract as ERC20" do
+    caller_deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "Caller",
+        "constructorArgs": {},
+      }
+    )
+    
+    erc20_receiver_deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "ERC20Receiver",
+        "constructorArgs": {},
+      }
+    )
+    
+    receiver_deploy_receipt = trigger_contract_interaction_and_expect_success(
+      command: 'deploy',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "protocol": "Receiver",
+        "constructorArgs": {},
+      }
+    )
+  
+    trigger_contract_interaction_and_expect_success(
+      command: 'call',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "contract": caller_deploy_receipt.address,
+        "functionName": "testImplements",
+        "args": {
+          "receiver": erc20_receiver_deploy_receipt.address,
+        },
+      }
+    )
+  
+    trigger_contract_interaction_and_expect_call_error(
+      command: 'call',
+      from: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+      data: {
+        "contract": caller_deploy_receipt.address,
+        "functionName": "testImplements",
+        "args": {
+          "receiver": receiver_deploy_receipt.address,
+        },
+      }
+    )
+  end
+end


### PR DESCRIPTION
Now you can say `ERC20(s.token0).balanceOf(address(this))` and it will verify if the contract you're trying to call implements `ERC20`.