### PR TITLE
Refactor valid contract type computation

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -13,8 +13,12 @@ class Contract < ApplicationRecord
   
   delegate :msg, :implements?, to: :implementation
   
+  class << self
+    delegate :valid_contract_types, to: ContractImplementation
+  end
+  
   def self.create_from_user!(deployer:, creation_ethscription_id:, type:)
-    unless valid_contract_types.include?(type)
+    unless valid_contract_types.include?(type.to_sym)
       raise TransactionError.new("Invalid contract type: #{type}")
     end
     
@@ -112,12 +116,6 @@ class Contract < ApplicationRecord
           code: source_code(k)
         }
       end
-    end
-  end
-  
-  def self.valid_contract_types
-    Contracts.constants.map do |c|
-      Contracts.const_get(c).to_s.demodulize
     end
   end
   

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
This is a more direct way of defining them and it doesn't rely on `method_missing` which should be a last resort.

Also enabled eager loading in test which is annoying because it makes things slower but we have no choice!