### PR TITLE
Improve syntax for calling parent contracts

### DIFF
--- a/app/models/abi_proxy.rb
+++ b/app/models/abi_proxy.rb
@@ -36,7 +36,7 @@ class AbiProxy
       end
   
       contract_class.class_eval do
-        define_method("_" + parent.name.demodulize) do
+        define_method(parent.name.demodulize) do
           contract_instance = self
           Object.new.tap do |proxy|
             parent.abi.data.each do |name, _|

--- a/app/models/contract_proxy.rb
+++ b/app/models/contract_proxy.rb
@@ -56,7 +56,10 @@ class ContractProxy
       define_singleton_method(name) do |*args, **kwargs|
         user_args = { args: args, kwargs: kwargs }
         
-        TransactionContext.set(msg_sender: caller_address) do
+        TransactionContext.set(
+          msg_sender: caller_address,
+          current_contract: to_contract,
+        ) do
           to_contract.execute_function(
             name,
             user_args,

--- a/app/models/contracts/ether_erc20_bridge.rb
+++ b/app/models/contracts/ether_erc20_bridge.rb
@@ -14,7 +14,7 @@ class Contracts::EtherERC20Bridge < ContractImplementation
     symbol: :string,
     trustedSmartContract: :address
   ) {
-    _ERC20.constructor(name: name, symbol: symbol, decimals: 18)
+    ERC20.constructor(name: name, symbol: symbol, decimals: 18)
     
     s.trustedSmartContract = trustedSmartContract
   }

--- a/app/models/contracts/ethscription_erc20_bridge.rb
+++ b/app/models/contracts/ethscription_erc20_bridge.rb
@@ -21,7 +21,7 @@ class Contracts::EthscriptionERC20Bridge < ContractImplementation
     trustedSmartContract: :address,
     ethscriptionDeployId: :ethscriptionId
   ) {
-    _ERC20.constructor(name: name, symbol: symbol, decimals: 18)
+    ERC20.constructor(name: name, symbol: symbol, decimals: 18)
     
     s.trustedSmartContract = trustedSmartContract
     s.ethscriptionDeployId = ethscriptionDeployId

--- a/app/models/contracts/generative_erc721.rb
+++ b/app/models/contracts/generative_erc721.rb
@@ -17,7 +17,7 @@ class Contracts::GenerativeERC721 < ContractImplementation
     description: :string,
     maxPerAddress: :uint256
   ) {
-    _ERC721.constructor(name: name, symbol: symbol)
+    ERC721.constructor(name: name, symbol: symbol)
     
     s.maxSupply = maxSupply
     s.maxPerAddress = maxPerAddress

--- a/app/models/contracts/open_edition_erc721.rb
+++ b/app/models/contracts/open_edition_erc721.rb
@@ -18,7 +18,7 @@ class Contracts::OpenEditionERC721 < ContractImplementation
     mintStart: :datetime,
     mintEnd: :datetime
   ) {
-    _ERC721.constructor(name: name, symbol: symbol)
+    ERC721.constructor(name: name, symbol: symbol)
     
     s.maxPerAddress = maxPerAddress
     s.description = description

--- a/app/models/contracts/public_mint_erc20.rb
+++ b/app/models/contracts/public_mint_erc20.rb
@@ -11,7 +11,7 @@ class Contracts::PublicMintERC20 < ContractImplementation
     perMintLimit: :uint256,
     decimals: :uint8
   ) {
-    _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
+    ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
     s.maxSupply = maxSupply
     s.perMintLimit = perMintLimit
   }

--- a/app/models/function_context.rb
+++ b/app/models/function_context.rb
@@ -15,14 +15,10 @@ class FunctionContext < BasicObject
     end
   end
   
-  def this
-    @contract
-  end
-  
   def require(*args)
     @contract.send(:require, *args)
   end
-
+  
   def respond_to_missing?(name, include_private = false)
     @args.respond_to?(name, include_private) || @contract.respond_to?(name, include_private)
   end

--- a/app/models/transaction_context.rb
+++ b/app/models/transaction_context.rb
@@ -1,7 +1,7 @@
 class TransactionContext < ActiveSupport::CurrentAttributes
   include ContractErrors
   
-  attribute :current_transaction
+  attribute :current_transaction, :current_contract
   delegate :log_event, :ethscription, to: :current_transaction
   
   def current_transaction=(new_value)
@@ -35,6 +35,10 @@ class TransactionContext < ActiveSupport::CurrentAttributes
     
       Struct.new(*struct_params).new(*struct_values)
     end
+  end
+  
+  def this
+    current_contract
   end
   
   def blockhash(input_block_number)

--- a/spec/models/contract_implementation_spec.rb
+++ b/spec/models/contract_implementation_spec.rb
@@ -4,7 +4,7 @@ class Contracts::ERC20Receiver < ContractImplementation
   is :ERC20
   
   constructor() {
-    _ERC20.constructor(name: "bye", symbol: "B", decimals: 18)
+    ERC20.constructor(name: "bye", symbol: "B", decimals: 18)
   }
 end
 

--- a/spec/models/inheritance_spec.rb
+++ b/spec/models/inheritance_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe AbiProxy, type: :model do
           symbol: :string,
           decimals: :uint8
         ) {
-          _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
+          ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
         }
         
         function :_mint, { to: :address, amount: :uint256 }, :public, :virtual, :override do
-          _ERC20._mint(to: to, amount: amount)
+          ERC20._mint(to: to, amount: amount)
           s.definedInTest = "definedInTest"
         end
         
@@ -35,7 +35,7 @@ RSpec.describe AbiProxy, type: :model do
           symbol: :string,
           decimals: :uint8
         ) {
-          _ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
+          ERC20.constructor(name: name, symbol: symbol, decimals: decimals)
         }
       end
     end
@@ -66,16 +66,16 @@ RSpec.describe AbiProxy, type: :model do
           symbol: :string,
           decimals: :uint8
         ) {
-          _TestContract.constructor(name: name, symbol: symbol, decimals: decimals)
-          _NonToken.constructor()
+          TestContract.constructor(name: name, symbol: symbol, decimals: decimals)
+          NonToken.constructor()
           
           s.definedHere = "definedHere"
         }
   
         function :_mint, { to: :address, amount: :uint256 }, :public, :override do
-          _TestContract._mint(to: to, amount: amount)
-          _NonToken._mint(to: to, amount: amount)
-          _ERC20._mint(to: to, amount: amount)
+          TestContract._mint(to: to, amount: amount)
+          NonToken._mint(to: to, amount: amount)
+          ERC20._mint(to: to, amount: amount)
         end
       end
     end
@@ -205,7 +205,7 @@ RSpec.describe AbiProxy, type: :model do
         is :TestContract
   
         function :nonVirtual, {}, :public, :override do
-          _ERC20._mint(to: to, amount: amount)
+          ERC20._mint(to: to, amount: amount)
         end
       end
     }.to raise_error(ContractErrors::InvalidOverrideError)


### PR DESCRIPTION
Now that we have `TransactionContext` managing our global transaction state we can finally have "the good version" and use `ERC20._mint()` instead of `_ERC20._mint()`.

This is because the "good version" relies on knowing the "current contract" which was not really possible under our previous approach to state.