### PR TITLE
`this` should be a `ContractImplementation`, not a `Contract` record

### DIFF
--- a/app/models/contract_implementation.rb
+++ b/app/models/contract_implementation.rb
@@ -212,7 +212,7 @@ class ContractImplementation
   end
   
   def address(i)
-    if i.is_a?(Contract) && i == self.contract_record
+    if i.is_a?(ContractImplementation) && i == self
       return TypedVariable.create(:address, contract_record.address)
     end
     

--- a/app/models/transaction_context.rb
+++ b/app/models/transaction_context.rb
@@ -38,7 +38,7 @@ class TransactionContext < ActiveSupport::CurrentAttributes
   end
   
   def this
-    current_contract
+    current_contract.implementation
   end
   
   def blockhash(input_block_number)


### PR DESCRIPTION
This way you can call `this.balanceOf()` etc. It's also how it was before.