### PR TITLE
Enable multiple return values

### DIFF
--- a/app/models/contract_errors.rb
+++ b/app/models/contract_errors.rb
@@ -31,4 +31,5 @@ module ContractErrors
   class InvalidOverrideError < StandardError; end
   class FunctionAlreadyDefinedError < StandardError; end
   class EthscriptionDoesNotTriggerContractInteractionError < StandardError; end
+  class InvalidDestructuringError < StandardError; end
 end

--- a/app/models/contracts/erc20_liquidity_pool.rb
+++ b/app/models/contracts/erc20_liquidity_pool.rb
@@ -21,13 +21,11 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
     )
   end
   
-  function :reserves, {}, :public, :view, returns: :string do
-    jsonData = {
+  function :reserves, {}, :public, :view, returns: { token0: :uint256, token1: :uint256 } do
+    return {
       token0: ERC20(s.token0).balanceOf(address(this)),
       token1: ERC20(s.token1).balanceOf(address(this))
-    }.to_json
-    
-    return "data:application/json,#{jsonData}"
+    }
   end
   
   function :calculateOutputAmount, {

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -688,6 +688,13 @@ RSpec.describe Contract, type: :model do
         }
       )
       
+      x = ContractTransaction.make_static_call(
+        contract: dex.address,
+        function_name: "reserves"
+      )
+      
+      expect(x).to be_a(Hash)
+      
       a = ContractTransaction.make_static_call(
         contract: token0.address,
         function_name: "balanceOf",


### PR DESCRIPTION
Like so:

```solidity
function :reserves, {}, :public, :view, returns: { token0: :uint256, token1: :uint256 } do
  return {
    token0: ERC20(s.token0).balanceOf(address(this)),
    token1: ERC20(s.token1).balanceOf(address(this))
  }
end
```

And called internally with `t0, t1 = reserves()`.

In Solidity for internal calls you must immediately destructure such return values. We cannot enforce this, so we wrap them in an object that can't really do anything but be destructured and can only be destructured once.