### PR TITLE
Static call results should convert integers to strings

### DIFF
--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -56,8 +56,18 @@ class ContractsController < ApplicationController
       return
     end
 
+    cooked_result = if result.is_a?(Integer)
+      result.to_s
+    elsif result.is_a?(Hash)
+      result.as_json.deep_transform_values do |value|
+        value.is_a?(Integer) ? value.to_s : value
+      end
+    else
+      result
+    end
+    
     render json: {
-      result: result.is_a?(Integer) ? result.to_s : result
+      result: cooked_result
     }
   end
 


### PR DESCRIPTION
For Javascript.

Maybe in the future we can abstract this into

`app/controllers/concerns/response_formatting.rb`

```ruby
module ResponseFormatting
  extend ActiveSupport::Concern

  def format_response(result)
    if result.is_a?(Integer)
      result.to_s
    elsif result.is_a?(Hash)
      result.as_json.deep_transform_values do |value|
        value.is_a?(Integer) ? value.to_s : value
      end
    else
      result
    end
  end
end
```

```ruby
class ContractsController < ApplicationController
  include ResponseFormatting

  # ...

  def static_call
    # ...

    cooked_result = format_response(result)

    render json: {
      result: cooked_result
    }
  end

  # ...
end
```