### PR TITLE
Stronger function return type enforcement

### DIFF
--- a/app/models/abi_proxy.rb
+++ b/app/models/abi_proxy.rb
@@ -217,8 +217,18 @@ class AbiProxy
     end
     
     def convert_return_to_typed_variable(ret_val)
-      return ret_val if ret_val.nil? || returns.nil?
+      return nil if constructor?
+      
+      if returns.nil?
+        return nil if ret_val.nil?
+        
+        raise ContractError, "Function #{func_location} returned #{ret_val.inspect}, but expected nil"
+      end
     
+      if ret_val.nil?
+        raise ContractError, "Function #{func_location} returned nil, but expected #{returns}"
+      end
+      
       if returns.is_a?(Hash)
         ret_val.each.with_object({}) do |(key, value), acc|
           acc[key.to_sym] = TypedVariable.create_or_validate(returns[key], value)

--- a/app/models/contracts/erc20_liquidity_pool.rb
+++ b/app/models/contracts/erc20_liquidity_pool.rb
@@ -7,7 +7,7 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
     s.token1 = token1
   end
   
-  function :addLiquidity, {token0Amount: :uint256, token1Amount: :uint256}, :public do
+  function :addLiquidity, {token0Amount: :uint256, token1Amount: :uint256}, :public, returns: :bool do
     ERC20(s.token0).transferFrom(
       from: msg.sender,
       to: address(this),

--- a/app/models/contracts/erc721.rb
+++ b/app/models/contracts/erc721.rb
@@ -67,9 +67,11 @@ class Contracts::ERC721 < ContractImplementation
     s._ownerOf[id] = to;
     
     s.getApproved[id] = address(0);
+    
+    return nil
   end
   
-  function :_exists, { id: :uint256 }, :internal, :virtual do
+  function :_exists, { id: :uint256 }, :internal, :virtual, returns: :bool do
     return s._ownerOf[id] != address(0)
   end
   

--- a/app/models/contracts/ether_bridge.rb
+++ b/app/models/contracts/ether_bridge.rb
@@ -77,7 +77,7 @@ class Contracts::EtherBridge < ContractImplementation
     return s.pendingUserWithdrawalIds[user]
   end
   
-  function :_removeFirstOccurenceOfValueFromArray, { arr: array(:bytes32), value: :bytes32 }, :internal do
+  function :_removeFirstOccurenceOfValueFromArray, { arr: array(:bytes32), value: :bytes32 }, :internal, returns: :bool do
     for i in 0...arr.length
       if arr[i] == value
         return _removeItemAtIndex(arr: arr, indexToRemove: i)

--- a/app/models/contracts/generative_erc721.rb
+++ b/app/models/contracts/generative_erc721.rb
@@ -25,7 +25,7 @@ class Contracts::GenerativeERC721 < ContractImplementation
     s.generativeScript = generativeScript
   }
   
-  function :mint, { amount: :uint256 }, :public do
+  function :mint, { amount: :uint256 }, :public, returns: :uint256 do
     require(amount > 0, 'Amount must be positive')
     require(amount + s._balanceOf[msg.sender] <= s.maxPerAddress, 'Exceeded mint limit')
     require(amount + s.totalSupply <= s.maxSupply, 'Exceeded max supply')

--- a/app/models/contracts/open_edition_erc721.rb
+++ b/app/models/contracts/open_edition_erc721.rb
@@ -27,7 +27,7 @@ class Contracts::OpenEditionERC721 < ContractImplementation
     s.mintEnd = mintEnd
   }
   
-  function :mint, { amount: :uint256 }, :public do
+  function :mint, { amount: :uint256 }, :public, returns: :uint256 do
     require(amount > 0, 'Amount must be positive')
     require(amount + s._balanceOf[msg.sender] <= s.maxPerAddress, 'Exceeded mint limit')
     require(block.timestamp >= s.mintStart, 'Minting has not started')

--- a/app/models/contracts/uniswap_v2_factory.rb
+++ b/app/models/contracts/uniswap_v2_factory.rb
@@ -45,11 +45,15 @@ class Contracts::UniswapV2Factory < ContractImplementation
     require(msg.sender == feeToSetter, "Scribeswap: FORBIDDEN")
     
     s.feeTo = _feeTo
+    
+    return nil
   end
 
   function :setFeeToSetter, { _feeToSetter: :address }, :public do
     require(msg.sender == feeToSetter, "Scribeswap: FORBIDDEN")
     
     s.feeToSetter = _feeToSetter
+    
+    return nil
   end
 end

--- a/app/models/contracts/uniswap_v2_pair.rb
+++ b/app/models/contracts/uniswap_v2_pair.rb
@@ -59,6 +59,8 @@ class Contracts::UniswapV2Pair < ContractImplementation
 
     s.token0 = _token0
     s.token1 = _token1
+    
+    return nil
   end
   
   function :_update, {
@@ -146,6 +148,8 @@ class Contracts::UniswapV2Pair < ContractImplementation
     s.kLast = s.reserve0 * s.reserve1 if feeOn
     
     emit :Mint, sender: msg.sender, amount0: amount0, amount1: amount1
+    
+    return liquidity
   end
   
   function :burn, { to: :address }, :external, :lock, returns: { amount0: :uint256, amount1: :uint256 } do

--- a/app/models/contracts/uniswap_v2_router.rb
+++ b/app/models/contracts/uniswap_v2_router.rb
@@ -128,6 +128,8 @@ class Contracts::UniswapV2Router < ContractImplementation
 
       UniswapV2Pair(pairFor(factory, input, output)).swap(amount0Out, amount1Out, to, "")
     end
+    
+    return nil
   end
   
   function :_safeTransferFrom, { token: :address, from: :address, to: :address, value: :uint256 }, :private do

--- a/spec/models/contract_implementation_spec.rb
+++ b/spec/models/contract_implementation_spec.rb
@@ -34,7 +34,7 @@ class Contracts::Receiver < ContractImplementation
   
   constructor() {}
   
-  function :sayHi, {}, :public, :view do
+  function :sayHi, {}, :public, :view, returns: :string do
     return "hi"
   end
   
@@ -70,7 +70,7 @@ class Contracts::Caller < ContractImplementation
     Receiver(receiver).internalCall()
   end
   
-  function :testImplements, { receiver: :address }, :public do
+  function :testImplements, { receiver: :address }, :public, returns: :string do
     ERC20(receiver).name()
   end
 end
@@ -128,7 +128,7 @@ end
 class Contracts::MultiDeployer < ContractImplementation
   constructor() {}
 
-  function :deployContracts, { deployerAddress: :address }, :public do
+  function :deployContracts, { deployerAddress: :address }, :public, returns: :address do
     contract = new CallerTwo(deployerAddress)
     
     testNoArgs = new MultiDeployer()
@@ -144,7 +144,7 @@ class Contracts::CallerTwo < ContractImplementation
     s.deployerAddress = deployerAddress
   }
   
-  function :callDeployer, {}, :public do
+  function :callDeployer, {}, :public, returns: :address do
     deployer = Deployer(s.deployerAddress)
 
     deployer.createERC20Minimal("myToken", "MTK", 18)

--- a/spec/models/inheritance_spec.rb
+++ b/spec/models/inheritance_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe AbiProxy, type: :model do
         }
         
         function :_mint, { to: :address, amount: :uint256 }, :public, :virtual, :override do
-          ERC20._mint(to: to, amount: amount)
           s.definedInTest = "definedInTest"
+          ERC20._mint(to: to, amount: amount)
         end
         
         function :nonVirtual, {}, :public do
@@ -49,8 +49,8 @@ RSpec.describe AbiProxy, type: :model do
         event :Greet, { greeting: :string }
         
         function :_mint, { to: :address, amount: :uint256 }, :public, :virtual do
-          emit :Greet, greeting: "Hello"
           s.definedInNonToken = "definedInNonToken"
+          emit :Greet, greeting: "Hello"
         end
       end
     end

--- a/spec/models/uniswap_v2_pair_spec.rb
+++ b/spec/models/uniswap_v2_pair_spec.rb
@@ -23,7 +23,7 @@ class Contracts::UniswapV2CalleeTester < ContractImplementation
     amount0: :uint256,
     amount1: :uint256,
     data: :bytes
-  }, :override, :external do
+  }, :override, :external, returns: :bool do
     balance0 = ERC20(s.token0).balanceOf(address(this))
     balance1 = ERC20(s.token1).balanceOf(address(this))
     


### PR DESCRIPTION
Now you must (manually if necessary) return nil if the signature calls for it and if the signature doesn't call for it you cannot return nil.

However you're allowed to return whatever you want from a constructor because they always have return value nil