### PR TITLE
Raise exception if read-only function tried to update state

### DIFF
--- a/app/models/contract_call.rb
+++ b/app/models/contract_call.rb
@@ -24,12 +24,13 @@ class ContractCall < ApplicationRecord
         find_and_validate_existing_contract!(to_contract_address)
       end
       
-      result = to_contract.execute_function(
-        function, args
-      )
+      result, state_changed = to_contract.execute_function(
+        function,
+        args
+      ).values_at(:result, :state_changed)
       
-      if function_object.read_only?
-        raise ActiveRecord::Rollback
+      if function_object.read_only? && state_changed
+        raise ReadOnlyFunctionChangedStateError, "Invalid change in read-only function: #{function}, #{args.inspect}, to address: #{to_contract.address}"
       end
     end
     

--- a/app/models/contract_errors.rb
+++ b/app/models/contract_errors.rb
@@ -32,4 +32,5 @@ module ContractErrors
   class FunctionAlreadyDefinedError < StandardError; end
   class InvalidEthscriptionError < StandardError; end
   class InvalidDestructuringError < StandardError; end
+  class ReadOnlyFunctionChangedStateError < StandardError; end
 end


### PR DESCRIPTION
Previously we were silently rolling the change back. But this error means something is wrong with the contract definition.