### PR TITLE
Stop always deleting earliest imported ethscription

### DIFF
--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -22,13 +22,6 @@ class Ethscription < ApplicationRecord
     )
   end
   
-  def delete_with_later_ethscriptions
-    Ethscription.transaction do
-      delete
-      later_ethscriptions.delete_all
-    end
-  end
-  
   def content
     content_uri[/.*?,(.*)/, 1]
   end

--- a/app/models/ethscription_sync.rb
+++ b/app/models/ethscription_sync.rb
@@ -51,16 +51,18 @@ class EthscriptionSync
         ethscription_id: ethscriptions.first[:ethscription_id]
       )
       
-      server_blockhash = ethscriptions.first[:block_blockhash]
-      our_blockhash = starting_ethscription&.block_blockhash
-      
-      Ethscription.transaction do
-        starting_ethscription&.later_ethscriptions&.delete_all
+      if starting_ethscription
+        server_blockhash = ethscriptions.first[:block_blockhash]
+        our_blockhash = starting_ethscription.block_blockhash
         
-        if server_blockhash != our_blockhash
-          starting_ethscription&.delete
-        else
-          ethscriptions.shift
+        Ethscription.transaction do
+          starting_ethscription.later_ethscriptions.delete_all
+          
+          if server_blockhash != our_blockhash
+            starting_ethscription.delete
+          else
+            ethscriptions.shift
+          end
         end
       end
       

--- a/app/models/ethscription_sync.rb
+++ b/app/models/ethscription_sync.rb
@@ -51,7 +51,18 @@ class EthscriptionSync
         ethscription_id: ethscriptions.first[:ethscription_id]
       )
       
-      starting_ethscription&.delete_with_later_ethscriptions
+      server_blockhash = ethscriptions.first[:block_blockhash]
+      our_blockhash = starting_ethscription&.block_blockhash
+      
+      Ethscription.transaction do
+        starting_ethscription&.later_ethscriptions&.delete_all
+        
+        if server_blockhash != our_blockhash
+          starting_ethscription&.delete
+        else
+          ethscriptions.shift
+        end
+      end
       
       sorted_response = ethscriptions.sort_by do |e|
         [e[:block_number], e[:transaction_index]]


### PR DESCRIPTION
Previously we were constantly deleting and re-adding the most recent transaction which led to some weird behavior.