### PR TITLE
Cache static call and simulation results

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -4,6 +4,8 @@ class Contract < ApplicationRecord
   include ContractErrors
     
   has_many :states, primary_key: 'address', foreign_key: 'contract_address', class_name: "ContractState"
+  has_one :newest_state, -> { newest_first }, class_name: 'ContractState', primary_key: 'address',
+    foreign_key: 'contract_address'
   belongs_to :contract_transaction, foreign_key: :transaction_hash, primary_key: :transaction_hash, optional: true
 
   belongs_to :ethscription, primary_key: 'ethscription_id', foreign_key: 'transaction_hash'
@@ -31,7 +33,7 @@ class Contract < ApplicationRecord
   end
   
   def current_state
-    states.newest_first.first || ContractState.new
+    newest_state || ContractState.new
   end
   
   def self.type_abstract?(type)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,15 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.cache_store = :memory_store
+    config.cache_store = :mem_cache_store,
+      'localhost',
+      {
+        failover: true,
+        socket_timeout: 1.5,
+        socket_failure_delay: 0.2,
+        down_retry_delay: 60,
+        compress: true
+      }
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }


### PR DESCRIPTION
Static calls and simulations are completely deterministic based on their inputs and the state of the VM. Therefore the VM shouldn't recompute unless state or inputs change.

This PR achieves this by using key-based memcache cache expiry.