### PR TITLE
Import new ethscriptions one block at a time

### DIFF
--- a/app/models/contract_test_helper.rb
+++ b/app/models/contract_test_helper.rb
@@ -84,16 +84,28 @@ module ContractTestHelper
     
     existing = Ethscription.newest_first.first
     
-    block_number = existing&.block_number.to_i + 1
+    block = EthBlock.order(imported_at: :desc).first
+    
+    block_number = block&.block_number.to_i + 1
     transaction_index = existing&.transaction_index.to_i + 1
+    
+    blockhash = "0x" + SecureRandom.hex(32)
+    
+    EthBlock.create!(
+      block_number: block_number,
+      blockhash: blockhash,
+      parent_blockhash: block&.blockhash || blockhash,
+      timestamp: Time.zone.now.to_i,
+      imported_at: Time.zone.now
+    )
     
     ethscription_attrs = {
       "ethscription_id"=>tx_hash,
       "block_number"=> block_number,
-      "block_blockhash"=> "0x" + SecureRandom.hex(32),
+      "block_blockhash"=> blockhash,
       "current_owner"=>from.downcase,
       "creator"=>from.downcase,
-      creation_timestamp: Time.zone.now,
+      creation_timestamp: Time.zone.now.to_i,
       "initial_owner"=>'0x0000000000000000000000000000000000000000',
       "transaction_index"=>transaction_index,
       "content_uri"=> uri,

--- a/app/models/contract_test_helper.rb
+++ b/app/models/contract_test_helper.rb
@@ -94,7 +94,7 @@ module ContractTestHelper
     EthBlock.create!(
       block_number: block_number,
       blockhash: blockhash,
-      parent_blockhash: block&.blockhash || blockhash,
+      parent_blockhash: block&.blockhash || "0x" + SecureRandom.hex(32),
       timestamp: Time.zone.now.to_i,
       imported_at: Time.zone.now
     )

--- a/app/models/eth_block.rb
+++ b/app/models/eth_block.rb
@@ -1,0 +1,30 @@
+class EthBlock < ApplicationRecord
+  has_many :ethscriptions, foreign_key: :block_number, primary_key: :block_number
+  
+  def import_ethscriptions(ethscriptions_data)
+    sorted_ethscriptions_data = ethscriptions_data.sort_by do |ethscription_data|
+      Integer(ethscription_data['transaction_index'])
+    end
+    
+    sorted_ethscriptions_data.each do |ethscription_data|
+      ethscriptions.create!(transform_server_response(ethscription_data))
+    end
+  end
+  
+  def transform_server_response(server_data)
+    {
+      ethscription_id: server_data['transaction_hash'],
+      block_number: block_number,
+      block_blockhash: blockhash,
+      transaction_index: server_data['transaction_index'],
+      creator: server_data['creator'],
+      current_owner: server_data['current_owner'],
+      initial_owner: server_data['initial_owner'],
+      creation_timestamp: timestamp,
+      previous_owner: server_data['previous_owner'],
+      content_uri: server_data['content_uri'],
+      content_sha: Digest::SHA256.hexdigest(server_data['content_uri']),
+      mimetype: server_data['mimetype']
+    }
+  end  
+end

--- a/app/models/eth_block.rb
+++ b/app/models/eth_block.rb
@@ -11,6 +11,8 @@ class EthBlock < ApplicationRecord
     end
   end
   
+  private
+  
   def transform_server_response(server_data)
     {
       ethscription_id: server_data['transaction_hash'],

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -1,4 +1,6 @@
 class Ethscription < ApplicationRecord
+  belongs_to :eth_block, foreign_key: :block_number, primary_key: :block_number, touch: true
+  
   has_many :contracts, primary_key: 'ethscription_id', foreign_key: 'transaction_hash'
   has_one :contract_transaction_receipt, primary_key: 'ethscription_id', foreign_key: 'transaction_hash'
   has_one :contract_transaction, primary_key: 'ethscription_id', foreign_key: 'transaction_hash'
@@ -13,13 +15,11 @@ class Ethscription < ApplicationRecord
   
   attr_accessor :mock_for_simulate_transaction
 
-  def later_ethscriptions
-    Ethscription.where(
-      'block_number > :block_number OR ' +
-      '(block_number = :block_number AND transaction_index > :transaction_index)',
-      block_number: block_number, 
-      transaction_index: transaction_index
-    )
+  def self.temp_tester
+    server = JSON.parse(IO.read(Rails.root.join('output.json')));nil
+    
+    us_but_not_them = Ethscription.where.not(ethscription_id: server.map{|i| i['ethscription_id']}).to_a; nil
+    them_but_not_us = server.map{|i| i['ethscription_id']}.to_set - Ethscription.pluck(:ethscription_id).to_set.to_a; nil
   end
   
   def content

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -15,13 +15,6 @@ class Ethscription < ApplicationRecord
   
   attr_accessor :mock_for_simulate_transaction
 
-  def self.temp_tester
-    server = JSON.parse(IO.read(Rails.root.join('output.json')));nil
-    
-    us_but_not_them = Ethscription.where.not(ethscription_id: server.map{|i| i['ethscription_id']}).to_a; nil
-    them_but_not_us = server.map{|i| i['ethscription_id']}.to_set - Ethscription.pluck(:ethscription_id).to_set.to_a; nil
-  end
-  
   def content
     content_uri[/.*?,(.*)/, 1]
   end

--- a/app/models/ethscription_sync.rb
+++ b/app/models/ethscription_sync.rb
@@ -49,7 +49,7 @@ class EthscriptionSync
       
       if our_previous_block
         if our_previous_block.blockhash != api_first_block['parent_blockhash']
-          our_previous_block.destroy
+          our_previous_block.destroy!
           Rails.logger.warn "Deleted block #{our_previous_block.block_number} because it had a different parent blockhash"
           return
         end
@@ -72,7 +72,7 @@ class EthscriptionSync
           eth_block.import_ethscriptions(block['ethscriptions'])
         end
       end
-      pp response['total_future_ethscriptions']
+      
       if Integer(response['total_future_ethscriptions']) == 0
         break
       end

--- a/db/migrate/20230928185853_create_eth_blocks.rb
+++ b/db/migrate/20230928185853_create_eth_blocks.rb
@@ -1,0 +1,60 @@
+class CreateEthBlocks < ActiveRecord::Migration[7.0]
+  def up
+    create_table :eth_blocks, force: :cascade do |t|
+      t.bigint :block_number, null: false
+      t.bigint :timestamp, null: false
+      t.string :blockhash, null: false
+      t.string :parent_blockhash, null: false
+      t.datetime :imported_at, null: false
+
+      t.index :blockhash, unique: true
+      t.index :block_number, unique: true
+      t.index :imported_at
+      
+      t.check_constraint "blockhash ~ '^0x[a-f0-9]{64}$'"
+      t.check_constraint "parent_blockhash ~ '^0x[a-f0-9]{64}$'"
+      
+      t.timestamps
+    end
+    
+    add_foreign_key :ethscriptions, :eth_blocks, column: :block_number, primary_key: "block_number", on_delete: :cascade
+    
+    change_column :ethscriptions, :creation_timestamp, 'bigint USING EXTRACT(EPOCH FROM creation_timestamp)'
+    
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION check_block_order()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        IF (SELECT MAX(block_number) FROM eth_blocks) IS NOT NULL AND (NEW.block_number <> (SELECT MAX(block_number) + 1 FROM eth_blocks) OR NEW.parent_blockhash <> (SELECT blockhash FROM eth_blocks WHERE block_number = NEW.block_number - 1)) THEN
+          RAISE EXCEPTION 'New block number must be equal to max block number + 1, or this must be the first block';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      
+      CREATE TRIGGER trigger_check_block_order
+      BEFORE INSERT ON eth_blocks
+      FOR EACH ROW EXECUTE FUNCTION check_block_order();
+    SQL
+    
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION delete_later_blocks()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        DELETE FROM eth_blocks WHERE block_number > OLD.block_number;
+        RETURN OLD;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER trigger_delete_later_blocks
+      AFTER DELETE ON eth_blocks
+      FOR EACH ROW EXECUTE FUNCTION delete_later_blocks();
+    SQL
+  end
+  
+  def down
+    drop_table :eth_blocks
+    
+    change_column :ethscriptions, :creation_timestamp, 'timestamp USING to_timestamp(creation_timestamp)'
+  end
+end

--- a/db/migrate/20230928185853_create_eth_blocks.rb
+++ b/db/migrate/20230928185853_create_eth_blocks.rb
@@ -8,6 +8,7 @@ class CreateEthBlocks < ActiveRecord::Migration[7.0]
       t.datetime :imported_at, null: false
 
       t.index :blockhash, unique: true
+      t.index :parent_blockhash, unique: true
       t.index :block_number, unique: true
       t.index :imported_at
       

--- a/spec/models/contract_state_spec.rb
+++ b/spec/models/contract_state_spec.rb
@@ -2,9 +2,23 @@ require 'rails_helper'
 
 RSpec.describe Contract, type: :model do
   before do
+    block = EthBlock.order(imported_at: :desc).first
+    
+    block_number = block&.block_number.to_i + 1
+    
+    blockhash = "0x" + SecureRandom.hex(32)
+
+    EthBlock.create!(
+      block_number: block_number,
+      blockhash: blockhash,
+      parent_blockhash: blockhash,
+      timestamp: Time.zone.now.to_i,
+      imported_at: Time.zone.now
+    )
+    
     @ethscription = Ethscription.create!(
       ethscription_id: '0x' + SecureRandom.hex(32),
-      block_number: 1,
+      block_number: block_number,
       block_blockhash: '0x' + SecureRandom.hex(32),
       transaction_index: 1,
       creator: '0x' + SecureRandom.hex(20),


### PR DESCRIPTION
Previously we were going one ethscription at a time. This was very fast but ultimately too difficult to make completely reorg resistant. Now we import blocks atomically and detect reorgs by verifying parent blockhashes.