### PR TITLE
Separate ethscription downloading from ethscription processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,5 @@ gem "rack-cors", "~> 2.0"
 gem "keccak256", "~> 2.0"
 
 gem "eth", "~> 0.5.11"
+
+gem "activerecord-import", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (7.0.7.2)
       activemodel (= 7.0.7.2)
       activesupport (= 7.0.7.2)
+    activerecord-import (1.5.0)
+      activerecord (>= 4.2)
     activestorage (7.0.7.2)
       actionpack (= 7.0.7.2)
       activejob (= 7.0.7.2)
@@ -235,6 +237,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import (~> 1.5)
   airbrake (~> 13.0)
   bootsnap
   clockwork (~> 3.0)

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 web: bundle exec puma -C config/puma.rb
 release: rake db:migrate
-clock: bundle exec clockwork config/clock.rb
+get_ethscriptions: bundle exec clockwork config/clock.rb
+process_ethscriptions: bundle exec clockwork config/processor_clock.rb

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -8,7 +8,7 @@ class StatusController < ApplicationController
       return
     end
     
-    total_newer_ethscriptions = Rails.cache.read("future_ethscriptions").to_i
+    total_newer_ethscriptions = Rails.cache.read("total_ethscriptions_behind").to_i
         
     resp = {
       oldest_known_ethscription: oldest_ethscription,

--- a/app/models/contract_test_helper.rb
+++ b/app/models/contract_test_helper.rb
@@ -96,7 +96,8 @@ module ContractTestHelper
       blockhash: blockhash,
       parent_blockhash: block&.blockhash || "0x" + SecureRandom.hex(32),
       timestamp: Time.zone.now.to_i,
-      imported_at: Time.zone.now
+      imported_at: Time.zone.now,
+      processing_state: "complete"
     )
     
     ethscription_attrs = {
@@ -114,6 +115,8 @@ module ContractTestHelper
     }
     
     eth = Ethscription.create!(ethscription_attrs)
+    ContractTransaction.create_from_ethscription!(eth)
+    
     eth.contract_transaction_receipt
   end
   

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -18,12 +18,21 @@ class ContractTransaction < ApplicationRecord
     "application/vnd.esc"
   end
   
-  def self.on_ethscription_created(ethscription)
+  def self.create_from_ethscription!(ethscription)
+    return unless ENV.fetch('ETHEREUM_NETWORK') == "eth-goerli" || Rails.env.development?
+    
     begin
       new_from_ethscription(ethscription).execute_transaction
     rescue InvalidEthscriptionError => e
-      Rails.logger.info(e.message)
+      Rails.logger.info "Invalid ethscription: #{e.message}"
     end
+    
+    end_time = Time.current
+    
+    ethscription.update_columns(
+      contract_actions_processed_at: end_time,
+      updated_at: end_time
+    )
   end
   
   def self.new_from_ethscription(ethscription)

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -21,18 +21,16 @@ class ContractTransaction < ApplicationRecord
   def self.create_from_ethscription!(ethscription)
     return unless ENV.fetch('ETHEREUM_NETWORK') == "eth-goerli" || Rails.env.development?
     
-    begin
+    ContractTransaction.transaction do
       new_from_ethscription(ethscription).execute_transaction
-    rescue InvalidEthscriptionError => e
-      Rails.logger.info "Invalid ethscription: #{e.message}"
+    
+      end_time = Time.current
+      
+      ethscription.update_columns(
+        contract_actions_processed_at: end_time,
+        updated_at: end_time
+      )
     end
-    
-    end_time = Time.current
-    
-    ethscription.update_columns(
-      contract_actions_processed_at: end_time,
-      updated_at: end_time
-    )
   end
   
   def self.new_from_ethscription(ethscription)
@@ -48,12 +46,11 @@ class ContractTransaction < ApplicationRecord
       self.payload = JSON.parse(ethscription.content)
       data = payload['data']
     rescue JSON::ParserError => e
-      raise InvalidEthscriptionError.new(
-        "JSON parse error: #{e.message}"
-      )
+      Rails.logger.info "JSON parse error: #{e.message}"
+      return
     end
     
-    validate_mimetype_and_to!
+    return unless mimetype_and_to_valid?
     
     assign_attributes(
       block_blockhash: ethscription.block_blockhash,
@@ -203,17 +200,17 @@ class ContractTransaction < ApplicationRecord
   
   private
   
-  def validate_mimetype_and_to!
+  def mimetype_and_to_valid?
     unless ethscription.initial_owner == ("0x" + "0" * 40) && ethscription.mimetype == ContractTransaction.required_mimetype
-      raise InvalidEthscriptionError.new(
-        "#{ethscription.inspect} does not trigger contract interaction"
-      )
+      Rails.logger.info("#{ethscription.inspect} does not trigger contract interaction")
+      return false
     end
     
     if payload['to'] && !payload['to'].to_s.match(/\A0x[a-f0-9]{40}\z/i)
-      raise InvalidEthscriptionError.new(
-        "#{ethscription.inspect} does not trigger contract interaction"
-      )
+      Rails.logger.info("#{ethscription.inspect} does not trigger contract interaction")
+      return false
     end
+    
+    true
   end
 end

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -114,7 +114,7 @@ class ContractTransaction < ApplicationRecord
           creator: from.downcase,
           creation_timestamp: Time.zone.now.to_i,
           initial_owner: "0x" + "0" * 40,
-          transaction_index: Ethscription.pluck(:transaction_index).last.to_i + 1,
+          transaction_index: Ethscription.newest_first.first&.transaction_index.to_i + 1,
           content_uri: uri,
           content_sha: Digest::SHA256.hexdigest(uri),
           mimetype: mimetype,

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -105,7 +105,8 @@ class ContractTransaction < ApplicationRecord
           blockhash: "0x" + SecureRandom.hex(32),
           parent_blockhash: "0x" + SecureRandom.hex(32),
           timestamp: Time.zone.now.to_i,
-          imported_at: Time.zone.now
+          imported_at: Time.zone.now,
+          processing_state: "complete"
         )
         
         ethscription_attrs = {
@@ -124,8 +125,9 @@ class ContractTransaction < ApplicationRecord
         }
         
         eth = Ethscription.create!(ethscription_attrs)
-        transaction_receipt = eth.contract_transaction.contract_transaction_receipt
-  
+        ContractTransaction.create_from_ethscription!(eth)
+        transaction_receipt = eth.contract_transaction_receipt
+        
         raise ActiveRecord::Rollback
       end
   

--- a/app/models/eth_block.rb
+++ b/app/models/eth_block.rb
@@ -1,16 +1,6 @@
 class EthBlock < ApplicationRecord
   has_many :ethscriptions, foreign_key: :block_number, primary_key: :block_number
   
-  def import_ethscriptions(ethscriptions_data)
-    sorted_ethscriptions_data = ethscriptions_data.sort_by do |ethscription_data|
-      Integer(ethscription_data['transaction_index'])
-    end
-    
-    sorted_ethscriptions_data.each do |ethscription_data|
-      ethscriptions.create!(transform_server_response(ethscription_data))
-    end
-  end
-  
   def self.process_contract_actions_until_done
     unprocessed_ethscriptions = Ethscription.where(contract_actions_processed_at: nil).count
     unimported_ethscriptions = Rails.cache.read("future_ethscriptions").to_i
@@ -40,7 +30,6 @@ class EthBlock < ApplicationRecord
         curr_time = Time.current
         
         batch_elapsed_time = curr_time - batch_start_time
-        elapsed_time = curr_time - start_time
         
         ethscriptions_per_second = batch_ethscriptions_processed.zero? ? 0 : batch_ethscriptions_processed / batch_elapsed_time.to_f
         

--- a/app/models/eth_block.rb
+++ b/app/models/eth_block.rb
@@ -11,6 +11,90 @@ class EthBlock < ApplicationRecord
     end
   end
   
+  def self.process_contract_actions_until_done
+    unprocessed_ethscriptions = Ethscription.where(contract_actions_processed_at: nil).count
+    unimported_ethscriptions = Rails.cache.read("future_ethscriptions").to_i
+    
+    total_remaining = unprocessed_ethscriptions + unimported_ethscriptions
+    
+    Rails.cache.write("total_ethscriptions_behind", total_remaining)
+    
+    iterations = 0
+    total_ethscriptions_processed = 0
+    batch_ethscriptions_processed = 0
+    
+    start_time = Time.current
+    batch_start_time = Time.current
+
+    loop do
+      iterations += 1
+
+      just_processed = process_contract_actions_for_next_block_with_ethscriptions
+      
+      return unless just_processed
+      
+      batch_ethscriptions_processed += just_processed
+      unprocessed_ethscriptions -= just_processed
+      
+      if iterations % 100 == 0
+        curr_time = Time.current
+        
+        batch_elapsed_time = curr_time - batch_start_time
+        elapsed_time = curr_time - start_time
+        
+        ethscriptions_per_second = batch_ethscriptions_processed.zero? ? 0 : batch_ethscriptions_processed / batch_elapsed_time.to_f
+        
+        total_remaining -= batch_ethscriptions_processed
+        
+        puts "Processed #{iterations} blocks in #{batch_elapsed_time}s"
+        puts " > Ethscriptions: #{batch_ethscriptions_processed}"
+        puts " > Ethscriptions / s: #{ethscriptions_per_second}"
+        puts " > Ethscriptions left: #{total_remaining}"
+        
+        unprocessed_ethscriptions = Ethscription.where(contract_actions_processed_at: nil).count
+        unimported_ethscriptions = Rails.cache.read("future_ethscriptions").to_i
+        
+        total_remaining = unprocessed_ethscriptions + unimported_ethscriptions
+        
+        Rails.cache.write("total_ethscriptions_behind", total_remaining)
+        
+        batch_start_time = curr_time
+        batch_ethscriptions_processed = 0
+      end
+      
+      break unless unprocessed_ethscriptions > 0
+    end
+  end
+  
+  def self.process_contract_actions_for_next_block_with_ethscriptions
+    EthBlock.transaction do
+      next_number = EthBlock.where(processing_state: 'pending').order(:block_number).limit(1).select(:block_number)
+
+      locked_next_block = EthBlock.where(block_number: next_number)
+                                  .lock("FOR UPDATE SKIP LOCKED")
+                                  .first
+
+      return unless locked_next_block
+  
+      ethscriptions = locked_next_block.ethscriptions.order(:transaction_index)
+  
+      ethscriptions.each do |e|
+        ContractTransaction.create_from_ethscription!(e)
+      end
+  
+      locked_next_block.update_columns(
+        processing_state: "complete",
+        updated_at: Time.current
+      )
+  
+      ethscriptions.length
+    end
+  end
+  
+  def build_new_ethscription(server_data)
+    Ethscription.new(transform_server_response(server_data))
+  end
+  
   private
   
   def transform_server_response(server_data)
@@ -28,5 +112,5 @@ class EthBlock < ApplicationRecord
       content_sha: Digest::SHA256.hexdigest(server_data['content_uri']),
       mimetype: server_data['mimetype']
     }
-  end  
+  end
 end

--- a/app/models/eth_block.rb
+++ b/app/models/eth_block.rb
@@ -51,11 +51,6 @@ class EthBlock < ApplicationRecord
         puts " > Ethscriptions / s: #{ethscriptions_per_second}"
         puts " > Ethscriptions left: #{total_remaining}"
         
-        unprocessed_ethscriptions = Ethscription.where(contract_actions_processed_at: nil).count
-        unimported_ethscriptions = Rails.cache.read("future_ethscriptions").to_i
-        
-        total_remaining = unprocessed_ethscriptions + unimported_ethscriptions
-        
         Rails.cache.write("total_ethscriptions_behind", total_remaining)
         
         batch_start_time = curr_time

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -6,8 +6,6 @@ class Ethscription < ApplicationRecord
   has_one :contract_transaction, primary_key: 'ethscription_id', foreign_key: 'transaction_hash'
   has_many :contract_states, primary_key: 'ethscription_id', foreign_key: 'transaction_hash'
 
-  after_create :process_contract_actions
-  
   before_validation :downcase_hex_fields
   
   scope :newest_first, -> { order(block_number: :desc, transaction_index: :desc) }
@@ -29,12 +27,6 @@ class Ethscription < ApplicationRecord
   end
   
   private
-  
-  def process_contract_actions
-    return unless ENV.fetch('ETHEREUM_NETWORK') == "eth-goerli" || Rails.env.development?
-    
-    ContractTransaction.on_ethscription_created(self)
-  end
   
   def downcase_hex_fields
     self.ethscription_id = ethscription_id.downcase

--- a/app/models/ethscription_sync.rb
+++ b/app/models/ethscription_sync.rb
@@ -54,7 +54,9 @@ class EthscriptionSync
       db_block_hash_map = db_blocks.each_with_object({}) { |block, hash| hash[block.block_number] = block.blockhash }
       api_block_hash_map = api_blocks.each_with_object({}) { |block, hash| hash[block['block_number']] = block['blockhash'] }
       
-      reorged_blocks = db_block_hash_map.keys.select do |block_number|
+      common_block_numbers = db_block_hash_map.keys & api_block_hash_map.keys
+
+      reorged_blocks = common_block_numbers.select do |block_number|
         db_block_hash_map[block_number] != api_block_hash_map[block_number]
       end
       
@@ -123,11 +125,7 @@ class EthscriptionSync
 
       new_blocks << new_block
 
-      sorted_ethscriptions_data = block['ethscriptions'].sort_by do |ethscription_data|
-        Integer(ethscription_data['transaction_index'])
-      end
-
-      sorted_ethscriptions_data.each do |ethscription_data|
+      block['ethscriptions'].each do |ethscription_data|
         new_ethscription = new_block.build_new_ethscription(ethscription_data)
         
         new_ethscriptions << new_ethscription

--- a/app/models/ethscription_sync.rb
+++ b/app/models/ethscription_sync.rb
@@ -83,7 +83,7 @@ class EthscriptionSync
       response = fetch_ethscriptions(next_block_number)
       
       if response.dig('error', 'resolution') == 'retry'
-        return
+        return 0
       elsif response['error']
         raise "Unexpected error: #{response['error']}"
       end

--- a/app/models/function_context.rb
+++ b/app/models/function_context.rb
@@ -1,7 +1,4 @@
 class FunctionContext < BasicObject
-  include ::Kernel
-  attr_reader :contract, :args
-  
   def initialize(contract, args)
     @contract = contract
     @args = args
@@ -15,17 +12,16 @@ class FunctionContext < BasicObject
     end
   end
   
-  def require(*args)
-    @contract.send(:require, *args)
-  end
-  
   def respond_to_missing?(name, include_private = false)
     @args.respond_to?(name, include_private) || @contract.respond_to?(name, include_private)
   end
   
   def self.define_and_call_function_method(contract, args, &block)
     context = new(contract, args)
-    context.define_singleton_method(:function_implementation, &block)
+    
+    singleton_class = (class << context; self; end)
+    singleton_class.send(:define_method, :function_implementation, &block)
+    
     context.function_implementation
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -21,7 +21,7 @@ module Clockwork
     end
   end
 
-  every(6.seconds, 'Sync ethscriptions') do
+  every(3.seconds, 'Sync ethscriptions') do
     EthscriptionSync.import_eth_blocks_until_done
   end
   

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -24,4 +24,8 @@ module Clockwork
   every(6.seconds, 'Sync ethscriptions') do
     EthscriptionSync.import_eth_blocks_until_done
   end
+  
+  every(5.minutes, 'check_for_reorgs') do
+    EthscriptionSync.check_for_reorgs
+  end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -25,7 +25,7 @@ module Clockwork
     EthscriptionSync.import_eth_blocks_until_done
   end
   
-  every(5.minutes, 'check_for_reorgs') do
+  every(2.minutes, 'check_for_reorgs') do
     EthscriptionSync.check_for_reorgs
   end
 end

--- a/config/processor_clock.rb
+++ b/config/processor_clock.rb
@@ -21,7 +21,7 @@ module Clockwork
     end
   end
 
-  every(6.seconds, 'Sync ethscriptions') do
-    EthscriptionSync.import_eth_blocks_until_done
+  every(1.seconds, 'EthBlock.process_contract_actions_until_done') do
+    EthBlock.process_contract_actions_until_done
   end
 end

--- a/db/migrate/20231001152142_add_contract_actions_processed_at.rb
+++ b/db/migrate/20231001152142_add_contract_actions_processed_at.rb
@@ -1,0 +1,79 @@
+class AddContractActionsProcessedAt < ActiveRecord::Migration[7.0]
+  def up
+    add_column :ethscriptions, :contract_actions_processed_at, :datetime
+    add_column :eth_blocks, :processing_state, :string, null: false
+    
+    add_index :eth_blocks, :processing_state
+    add_index :eth_blocks, :block_number, where: "processing_state = 'complete'", name: 'index_eth_blocks_on_block_number_completed'
+    add_index :eth_blocks, :block_number, where: "processing_state = 'pending'", name: 'index_eth_blocks_on_block_number_pending'
+
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION check_block_sequence()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        IF NEW.processing_state = 'complete' THEN
+          IF EXISTS (
+            SELECT 1
+            FROM eth_blocks
+            WHERE block_number < NEW.block_number
+              AND processing_state = 'pending'
+            LIMIT 1
+          ) THEN
+            RAISE EXCEPTION 'Previous block not yet processed';
+          END IF;
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      
+      CREATE TRIGGER check_block_sequence_trigger
+      BEFORE UPDATE OF processing_state ON eth_blocks
+      FOR EACH ROW EXECUTE FUNCTION check_block_sequence();
+    SQL
+    
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION check_ethscription_sequence()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        IF NEW.contract_actions_processed_at IS NOT NULL THEN
+          IF EXISTS (
+            SELECT 1
+            FROM ethscriptions
+            WHERE 
+              (block_number < NEW.block_number AND contract_actions_processed_at IS NULL)
+              OR 
+              (block_number = NEW.block_number AND transaction_index < NEW.transaction_index AND contract_actions_processed_at IS NULL)
+            LIMIT 1
+          ) THEN
+            RAISE EXCEPTION 'Previous ethscription with either a lower block number or a lower transaction index in the same block not yet processed';
+          END IF;
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      
+      CREATE TRIGGER check_ethscription_sequence_trigger
+      BEFORE UPDATE OF contract_actions_processed_at ON ethscriptions
+      FOR EACH ROW EXECUTE FUNCTION check_ethscription_sequence();
+    SQL
+    
+  end
+  
+  def down
+    execute <<-SQL
+      DROP TRIGGER check_block_sequence_trigger ON eth_blocks;
+      DROP TRIGGER check_ethscription_sequence_trigger ON ethscriptions;
+    SQL
+  
+    execute <<-SQL
+      DROP FUNCTION check_block_sequence();
+      DROP FUNCTION check_ethscription_sequence();
+    SQL
+    
+    remove_index :eth_blocks, name: 'index_eth_blocks_on_block_number_completed'
+    remove_index :eth_blocks, name: 'index_eth_blocks_on_block_number_pending'
+
+    remove_column :ethscriptions, :contract_actions_processed_at, :datetime
+    remove_column :eth_blocks, :processing_state, :string, null: false
+  end
+end

--- a/db/migrate/20231001152142_add_contract_actions_processed_at.rb
+++ b/db/migrate/20231001152142_add_contract_actions_processed_at.rb
@@ -56,7 +56,6 @@ class AddContractActionsProcessedAt < ActiveRecord::Migration[7.0]
       BEFORE UPDATE OF contract_actions_processed_at ON ethscriptions
       FOR EACH ROW EXECUTE FUNCTION check_ethscription_sequence();
     SQL
-    
   end
   
   def down

--- a/spec/models/contract_state_spec.rb
+++ b/spec/models/contract_state_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Contract, type: :model do
       blockhash: blockhash,
       parent_blockhash: blockhash,
       timestamp: Time.zone.now.to_i,
-      imported_at: Time.zone.now
+      imported_at: Time.zone.now,
+      processing_state: "complete"
     )
     
     @ethscription = Ethscription.create!(


### PR DESCRIPTION
Also we now skip processing blocks with no ethscriptions (though we do import them to ensure we haven't missed anything).

This speeds things up significantly when ethscriptions are spread out among many blocks. However when ethscriptions are dense the time to process them is the dominant factor and the improvements here are marginal.