### PR TITLE
WIP: Reimplement mapping to be faster

### DIFF
--- a/app/models/array_type.rb
+++ b/app/models/array_type.rb
@@ -3,7 +3,7 @@ class ArrayType < TypedVariable
     super
   end
   
-  def serialize
+  def serialize(*)
     value.data.map(&:serialize)
   end
   

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -60,13 +60,15 @@ class Contract < ApplicationRecord
       final_state = implementation.state_proxy.serialize
       
       if final_state != initial_state
+        binding.pry if TransactionContext.function_object.read_only?
+        
         states.create!(
           transaction_hash: TransactionContext.transaction_hash,
           block_number: TransactionContext.block_number,
           transaction_index: TransactionContext.transaction_index,
           internal_transaction_index: TransactionContext.current_call.internal_transaction_index,
           state: final_state
-        )
+        ) rescue binding.pry
         
         state_changed = true
       end

--- a/app/models/contract_call.rb
+++ b/app/models/contract_call.rb
@@ -23,11 +23,13 @@ class ContractCall < ApplicationRecord
       else
         find_and_validate_existing_contract!(to_contract_address)
       end
-      
+      result, state_changed =nil
+      TransactionContext.set(function_object: function_object) do
       result, state_changed = to_contract.execute_function(
         function,
         args
       ).values_at(:result, :state_changed)
+    end
       
       if function_object.read_only? && state_changed
         raise ReadOnlyFunctionChangedStateError, "Invalid change in read-only function: #{function}, #{args.inspect}, to address: #{to_contract.address}"

--- a/app/models/contract_type.rb
+++ b/app/models/contract_type.rb
@@ -3,7 +3,7 @@ class ContractType < TypedVariable
     super
   end
   
-  def serialize
+  def serialize(...)
     value.address
   end
   

--- a/app/models/eth_block.rb
+++ b/app/models/eth_block.rb
@@ -90,6 +90,25 @@ class EthBlock < ApplicationRecord
     end
   end
   
+  def self.process_ethscriptions(num)
+    b = find_by_block_number(num)
+    
+    EthBlock.transaction do
+      ethscriptions = b.ethscriptions.order(:transaction_index)
+  
+      ethscriptions.each do |e|
+        ContractTransaction.create_from_ethscription!(e)
+      end
+  
+      b.update_columns(
+        processing_state: "complete",
+        updated_at: Time.current
+      )
+  
+      ethscriptions.length
+    end
+  end
+  
   def build_new_ethscription(server_data)
     Ethscription.new(transform_server_response(server_data))
   end

--- a/app/models/transaction_context.rb
+++ b/app/models/transaction_context.rb
@@ -2,7 +2,7 @@ class TransactionContext < ActiveSupport::CurrentAttributes
   include ContractErrors
   
   attribute :call_stack, :ethscription, :current_call,
-  :transaction_hash, :transaction_index, :current_transaction
+  :transaction_hash, :transaction_index, :current_transaction, :function_object
   
   STRUCT_DETAILS = {
     msg:    { attributes: { sender: :address } },

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -222,12 +222,14 @@ class Type
         raise VariableTypeError.new("invalid #{literal}")
       end
       
-      data = literal.map do |key, value|
-        [
-          TypedVariable.create(key_type, key),
-          TypedVariable.create(value_type, value)
-        ]
-      end.to_h
+      # data = literal.map do |key, value|
+      #   [
+      #     TypedVariable.create(key_type, key),
+      #     TypedVariable.create(value_type, value)
+      #   ]
+      # end.to_h
+      
+      data = literal
     
       proxy = MappingType::Proxy.new(data, key_type: key_type, value_type: value_type)
       

--- a/app/models/typed_variable.rb
+++ b/app/models/typed_variable.rb
@@ -35,11 +35,15 @@ class TypedVariable
   end
   
   def as_json(args = {})
-    serialize
+    serialize(convert_ints_to_strings: false)
   end
   
-  def serialize
-    value
+  def serialize(convert_ints_to_strings: true)
+    if value.is_a?(Integer) && convert_ints_to_strings
+      value.to_s
+    else
+      value
+    end
   end
   
   def to_s

--- a/spec/models/inheritance_spec.rb
+++ b/spec/models/inheritance_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe AbiProxy, type: :model do
     expect(call_receipt.logs.map{|i| i['event']}.sort)
     .to eq(['Greet', 'Transfer', 'Transfer'].sort)
     
-    expect(call_receipt.contract.latest_state['totalSupply']).to eq(10)
+    expect(call_receipt.contract.latest_state['totalSupply']).to eq("10")
     
     expect(call_receipt.contract.latest_state.
       slice('definedHere', 'definedInTest', 'definedInNonToken').values.sort).to eq(


### PR DESCRIPTION
Instead of transforming every mapping element into a `TypedVariable` on deserialization, leave them as regular values and "lazily" convert them to `TypedVariable`s when they are accessed.

This makes a big difference on ERC20s when you have balancesOf but also allowance, the latter of which is a nested mapping.

But it also makes the code more complicated. Now might not be the time.